### PR TITLE
Add solution with initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # ConnyConsole
-ConnyConsole is a console CLI playground for testing different ways of console implementations incl. argument parsing. Maybe, somewhen it becomes a CLI sample collection.
+ConnyConsole is a console CLI project that uses `System.CommandLine` from Microsoft for argument parsing to collect some experience with this library.
+
+Following some references/documentation:
+- [Parse the Command Line with System.CommandLine][1]
+- [System.CommandLine overview][2]
+- [System.CommandLine on GitHub][3]
+- [Tutorial: Get started with System.CommandLine][4]
+
+<!--# references --->
+[1]: https://learn.microsoft.com/en-us/archive/msdn-magazine/2019/march/net-parse-the-command-line-with-system-commandline "Parse the Command Line with System.CommandLine"
+[2]: https://learn.microsoft.com/en-us/dotnet/standard/commandline/ "System.CommandLine overview"
+[3]: https://github.com/dotnet/command-line-api "GitHub: dotnet > command-line-api"
+[4]: https://learn.microsoft.com/en-us/dotnet/standard/commandline/get-started-tutorial "Tutorial: Get started with System.CommandLine"

--- a/src/ConnyConsole.sln
+++ b/src/ConnyConsole.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnyConsole", "ConnyConsole/ConnyConsole.csproj", "{88969CC9-34FC-4668-902F-9D5354CE92E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/ConnyConsole.sln.DotSettings
+++ b/src/ConnyConsole.sln.DotSettings
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:s="clr-namespace:System;assembly=mscorlib"
+                        xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
+                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>

--- a/src/ConnyConsole/App.cs
+++ b/src/ConnyConsole/App.cs
@@ -1,0 +1,44 @@
+﻿using ConnyConsole.Infrastructure;
+using ConnyConsole.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ConnyConsole;
+
+public class App
+{
+    private readonly AppSettings _appSettings;
+    private readonly CancellationTokenFactory _cancellationTokenFactory;
+    private readonly ILogger<App> _logger;
+
+    public App(IOptions<AppSettings> appSettings, CancellationTokenFactory cancellationTokenFactory, ILogger<App> logger)
+    {
+        _appSettings = appSettings.Value;
+        _cancellationTokenFactory = cancellationTokenFactory;
+        _logger = logger;
+
+        RegisterCancellation();
+    }
+
+    public Task<int> RunAsync()
+    {
+        while (!_cancellationTokenFactory.CancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("I'm working every {LoopOutputInterval} seconds...",
+                _appSettings.LoopOutputInterval.TotalSeconds);
+
+            // just some dirty pseudo work
+            Thread.Sleep(_appSettings.LoopOutputInterval);
+        }
+
+        _logger.LogInformation("Bye bye!");
+
+        return Task.FromResult(0);
+    }
+
+    private void RegisterCancellation()
+    {
+        Console.CancelKeyPress +=
+            _cancellationTokenFactory.CreateHandler(_appSettings.CancellationTimeout);
+    }
+}

--- a/src/ConnyConsole/Config/appsettings.Development.json
+++ b/src/ConnyConsole/Config/appsettings.Development.json
@@ -1,0 +1,18 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Debug",
+        "Microsoft": "Information"
+      },
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  }
+}

--- a/src/ConnyConsole/Config/appsettings.json
+++ b/src/ConnyConsole/Config/appsettings.json
@@ -1,0 +1,26 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "System": "Warning",
+      "Microsoft": "Warning"
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      },
+      "FormatterName": "console",
+      "FormatterOptions": {
+        "SingleLine": true,
+        "IncludeScopes": false,
+        "TimestampFormat": "HH:mm:ss.fff "
+      }
+    }
+  },
+  "AppSettings": {
+    "LoopOutputInterval": "00:00:02",
+    "CancellationTimeout": "00:00:03"
+  }
+}

--- a/src/ConnyConsole/ConnyConsole.csproj
+++ b/src/ConnyConsole/ConnyConsole.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.1.25080.5" />
+      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="Config\appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Config\appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
+</Project>

--- a/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using ConnyConsole.Infrastructure;
+using ConnyConsole.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    // ReSharper disable once UnusedMethodReturnValue.Global
+    public static IServiceCollection AddConfiguration(this IServiceCollection services, HostBuilderContext hostContext)
+    {
+        services.Configure<AppSettings>(hostContext.Configuration.GetSection(AppSettings.SectionName));
+
+        services.AddLogging(builder => builder.AddConsole());
+
+        services.AddTransient<CancellationTokenFactory>();
+        services.AddTransient<App>();
+
+        return services;
+    }
+}

--- a/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
+++ b/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
@@ -1,0 +1,57 @@
+﻿// This class function is based on https://medium.com/@sawyer.watts/a-beginners-guide-to-net-s-hostbuilder-part-2-cancellation-857ae3e6ff02
+
+using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Infrastructure;
+
+public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> logger)
+{
+    private bool _gracefulCancel = true;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    public CancellationToken CancellationToken => _cancellationTokenSource.Token;
+
+    /// <summary>
+    /// Creates a <see cref="ConsoleCancelEventHandler"/> for a gracefully (first Ctrl+C) or forced (second Ctrl+C) application exit.
+    /// It can be registered on the <see cref="Console.CancelKeyPress"/> event.
+    /// </summary>
+    /// <param name="timeout">The timeout after which the app is forcibly terminated.</param>
+    /// <returns>The configured <see cref="ConsoleCancelEventHandler"/> event.</returns>
+    public ConsoleCancelEventHandler CreateHandler(TimeSpan timeout)
+    {
+        return (_, cancelEvent) =>
+        {
+            if (_gracefulCancel)
+            {
+                logger.LogInformation(
+                    $"Received interrupt signal, attempting to shut down gracefully but will force-close in {timeout.TotalSeconds} seconds. Send again to immediately force-close.");
+
+                _cancellationTokenSource.Cancel();
+                cancelEvent.Cancel = true;
+                _gracefulCancel = false;
+
+                ForceExitAfterTimeout((int)timeout.TotalMilliseconds);
+            }
+            else
+            {
+                logger.LogInformation("Second interrupt received, force-closing the app");
+            }
+        };
+    }
+
+    /// <summary>
+    /// Waits a defined timeout in milliseconds, afterward enforces the application exit.
+    /// </summary>
+    private void ForceExitAfterTimeout(int timeoutInMilliseconds)
+    {
+        _ = new Timer(
+            _ =>
+            {
+                logger.LogInformation("Timeout reached, force-closing app.");
+                Environment.Exit(0);
+            },
+            state: null,
+            dueTime: timeoutInMilliseconds,
+            period: 0);
+    }
+}

--- a/src/ConnyConsole/Program.cs
+++ b/src/ConnyConsole/Program.cs
@@ -1,0 +1,44 @@
+﻿using ConnyConsole;
+using ConnyConsole.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var logger = LoggerFactory.Create(config =>
+        config.AddSimpleConsole(options =>
+        {
+            options.SingleLine = true;
+            options.TimestampFormat = "HH:mm:ss.fff ";
+        }))
+    .CreateLogger<Program>();
+
+logger.LogInformation("Starting application...");
+
+int exitCode;
+try
+{
+    var host = Host.CreateDefaultBuilder(args)
+        .ConfigureAppConfiguration((hostContext, hostConfig) =>
+        {
+            var env = hostContext.HostingEnvironment;
+
+            hostConfig.AddJsonFile("Config/appsettings.json", optional: false, reloadOnChange: true);
+            hostConfig.AddJsonFile($"Config/appsettings.{env.EnvironmentName}.json", optional: true,
+                reloadOnChange: true);
+        })
+        .ConfigureServices((hostContext, services) => services.AddConfiguration(hostContext))
+        .Build();
+
+    var app = host.Services.GetRequiredService<App>();
+    exitCode = await app.RunAsync().ConfigureAwait(false);
+}
+catch (Exception e)
+{
+    logger.LogError(e, "Failed to start application");
+    exitCode = -1;
+}
+
+logger.LogInformation("Application shutdown.");
+
+return exitCode;

--- a/src/ConnyConsole/Settings/AppSettings.cs
+++ b/src/ConnyConsole/Settings/AppSettings.cs
@@ -1,0 +1,10 @@
+namespace ConnyConsole.Settings;
+
+public class AppSettings
+{
+    public const string SectionName = "AppSettings";
+
+    public TimeSpan LoopOutputInterval { get; init; }
+
+    public TimeSpan CancellationTimeout { get; init; }
+}


### PR DESCRIPTION
Created a solution that contains a console project and implemented dependency injection via HostBuilder. Furthermore, some startup logging was setup, whereby the Microsoft Console logger was configured for usage via dependency injection, based on appsettings.json file configuration. In addition, the console app got some dirty pseudo worker code added for simulating that something happens and to check if the cancellation implementation works.