### PR TITLE
Use Serilog for file and console logging

### DIFF
--- a/src/ConnyConsole/Config/appsettings.Development.json
+++ b/src/ConnyConsole/Config/appsettings.Development.json
@@ -1,17 +1,11 @@
 ﻿{
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Debug",
-        "Microsoft": "Information"
-      },
-      "FormatterOptions": {
-        "IncludeScopes": true
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.DbLoggerCategory.Database.Command": "Information"
       }
     }
   }

--- a/src/ConnyConsole/Config/appsettings.json
+++ b/src/ConnyConsole/Config/appsettings.json
@@ -1,22 +1,35 @@
 ﻿{
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "System": "Warning",
-      "Microsoft": "Warning"
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Information",
+      "Override": {
         "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      },
-      "FormatterName": "console",
-      "FormatterOptions": {
-        "SingleLine": true,
-        "IncludeScopes": false,
-        "TimestampFormat": "HH:mm:ss.fff "
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.DbLoggerCategory.Database.Command": "Information"
       }
+    },
+    "Using": [
+      "Serilog.Sinks.File",
+      "Serilog.Sinks.Console"
+    ],
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "Logs/On-.log",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u4}] {SourceContext} {Message:lj}{NewLine}{Exception}",
+          "rollingInterval": "Day"
+        }
+      },
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u4}] {SourceContext} {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Properties": {
+      "Application": "ConnyConsole"
     }
   },
   "AppSettings": {

--- a/src/ConnyConsole/ConnyConsole.csproj
+++ b/src/ConnyConsole/ConnyConsole.csproj
@@ -21,7 +21,8 @@
       <None Update="Config\appsettings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Update="Config\appsettings.Development.json">
+      <None Update="Config\appsettings.*.json">
+        <DependentUpon>appsettings.json</DependentUpon>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
     </ItemGroup>

--- a/src/ConnyConsole/ConnyConsole.csproj
+++ b/src/ConnyConsole/ConnyConsole.csproj
@@ -8,7 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.1.25080.5" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+      <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using ConnyConsole.Infrastructure;
 using ConnyConsole.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using Serilog;
 
 namespace ConnyConsole.Extensions;
 
@@ -11,9 +11,11 @@ public static class ServiceCollectionExtensions
     // ReSharper disable once UnusedMethodReturnValue.Global
     public static IServiceCollection AddConfiguration(this IServiceCollection services, HostBuilderContext hostContext)
     {
-        services.Configure<AppSettings>(hostContext.Configuration.GetSection(AppSettings.SectionName));
+        services.AddSerilog(loggerConfig =>
+            loggerConfig.ReadFrom.Configuration(hostContext.Configuration)
+                .Enrich.FromLogContext());
 
-        services.AddLogging(builder => builder.AddConsole());
+        services.Configure<AppSettings>(hostContext.Configuration.GetSection(AppSettings.SectionName));
 
         services.AddTransient<CancellationTokenFactory>();
         services.AddTransient<App>();

--- a/src/ConnyConsole/Program.cs
+++ b/src/ConnyConsole/Program.cs
@@ -3,17 +3,16 @@ using ConnyConsole.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Formatting.Display;
 
-var logger = LoggerFactory.Create(config =>
-        config.AddSimpleConsole(options =>
-        {
-            options.SingleLine = true;
-            options.TimestampFormat = "HH:mm:ss.fff ";
-        }))
-    .CreateLogger<Program>();
+Log.Logger = new LoggerConfiguration()
+    .Enrich.FromLogContext()
+    .WriteTo.Console(new MessageTemplateTextFormatter(
+        "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u4}] {SourceContext} {Message:lj}{NewLine}{Exception}"))
+    .CreateBootstrapLogger();
 
-logger.LogInformation("Starting application...");
+Log.Logger.ForContext<Program>().Information("Starting application");
 
 int exitCode;
 try
@@ -35,10 +34,13 @@ try
 }
 catch (Exception e)
 {
-    logger.LogError(e, "Failed to start application");
+    Log.Logger.ForContext<Program>().Error(e, "Failed to start application");
     exitCode = -1;
 }
-
-logger.LogInformation("Application shutdown.");
+finally
+{
+    Log.Logger.ForContext<Program>().Information("Application shutting down...");
+    Log.CloseAndFlush();
+}
 
 return exitCode;


### PR DESCRIPTION
Introduce Serilog + nest appsettings.json files

Now Serilog is used to log into files and on the console to reflect a
real scenario.
Just for a better overview, stage specific appsettings.<stage>.json
files are now nested on the original appsettings.json to make it obvious
in which order they are applied.