### PR TITLE
Fix by SonarQube (re)marked issues

### DIFF
--- a/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
+++ b/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
@@ -24,7 +24,7 @@ public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> l
             if (_gracefulCancel)
             {
                 logger.LogInformation(
-                    $"Received interrupt signal, attempting to shut down gracefully but will force-close in {timeout.TotalSeconds} seconds. Send again to immediately force-close.");
+                    "Received interrupt signal, attempting to shut down gracefully but will force-close in {Seconds} seconds. Send again to immediately force-close.",timeout.TotalSeconds);
 
                 _cancellationTokenSource.Cancel();
                 cancelEvent.Cancel = true;

--- a/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
+++ b/src/ConnyConsole/Infrastructure/CancellationTokenFactory.cs
@@ -4,12 +4,20 @@ using Microsoft.Extensions.Logging;
 
 namespace ConnyConsole.Infrastructure;
 
-public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> logger)
+public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> logger) : IDisposable
 {
     private bool _gracefulCancel = true;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
 
     public CancellationToken CancellationToken => _cancellationTokenSource.Token;
+
+    /// <summary>
+    /// Releases the resources used by this <see cref="CancellationTokenSource"/>
+    /// </summary>
+    /// <remarks>
+    /// This method is not thread-safe for any other concurrent calls.
+    /// </remarks>
+    public void Dispose() => _cancellationTokenSource.Dispose();
 
     /// <summary>
     /// Creates a <see cref="ConsoleCancelEventHandler"/> for a gracefully (first Ctrl+C) or forced (second Ctrl+C) application exit.

--- a/src/ConnyConsole/Program.cs
+++ b/src/ConnyConsole/Program.cs
@@ -40,7 +40,7 @@ catch (Exception e)
 finally
 {
     Log.Logger.ForContext<Program>().Information("Application shutting down...");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }
 
 return exitCode;


### PR DESCRIPTION
Now the Serilog logger is closed and flushed asynchronously at the end,
because the host instance is already run async and so the whole
top-level statement becomes async automatically. This change addresses
the by SonarQube remarked issue csharpsquid:S6966

Removed a string interpolation from a log message, which should fix
SonarQube issue csharpsquid:S2629 and in theory Roslyn issues
roslyn:CA2254 and external_roslyn:CA2254 as well.

Due the CancellationTokenSource implements IDisposable and this is used
within the CancellationTokenFactory, the latter has to implement
IDisposable too to ensure that the hold CancellationTokenSource is
freed up properly. This addresses SonarQube issue csharpsquid:S2930.