### PR TITLE
Simplify cancellation token creation and handling

### DIFF
--- a/src/ConnyConsole.sln.DotSettings
+++ b/src/ConnyConsole.sln.DotSettings
@@ -1,6 +1,4 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:s="clr-namespace:System;assembly=mscorlib"
-                        xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
-                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hostbuilder/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/ConnyConsole/App.cs
+++ b/src/ConnyConsole/App.cs
@@ -8,21 +8,21 @@ namespace ConnyConsole;
 public class App
 {
     private readonly AppSettings _appSettings;
-    private readonly CancellationTokenFactory _cancellationTokenFactory;
+    private readonly ConsoleCancellationTokenSource _consoleCancellationTokenSource;
     private readonly ILogger<App> _logger;
 
-    public App(IOptions<AppSettings> appSettings, CancellationTokenFactory cancellationTokenFactory, ILogger<App> logger)
+    public App(IOptions<AppSettings> appSettings, ConsoleCancellationTokenSource consoleCancellationTokenSource, ILogger<App> logger)
     {
         _appSettings = appSettings.Value;
-        _cancellationTokenFactory = cancellationTokenFactory;
+        _consoleCancellationTokenSource = consoleCancellationTokenSource;
         _logger = logger;
 
-        RegisterCancellation();
+        RegisterConsoleCancellation();
     }
 
     public Task<int> RunAsync()
     {
-        while (!_cancellationTokenFactory.CancellationToken.IsCancellationRequested)
+        while (!_consoleCancellationTokenSource.Token.IsCancellationRequested)
         {
             _logger.LogInformation("I'm working every {LoopOutputInterval} seconds...",
                 _appSettings.LoopOutputInterval.TotalSeconds);
@@ -36,9 +36,9 @@ public class App
         return Task.FromResult(0);
     }
 
-    private void RegisterCancellation()
+    private void RegisterConsoleCancellation()
     {
         Console.CancelKeyPress +=
-            _cancellationTokenFactory.CreateHandler(_appSettings.CancellationTimeout);
+            _consoleCancellationTokenSource.CreateCancellationHandler(_appSettings.CancellationTimeout);
     }
 }

--- a/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ConnyConsole/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
 
         services.Configure<AppSettings>(hostContext.Configuration.GetSection(AppSettings.SectionName));
 
-        services.AddTransient<CancellationTokenFactory>();
+        services.AddTransient<ConsoleCancellationTokenSource>();
         services.AddTransient<App>();
 
         return services;

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
@@ -1,23 +1,12 @@
-﻿// This class function is based on https://medium.com/@sawyer.watts/a-beginners-guide-to-net-s-hostbuilder-part-2-cancellation-857ae3e6ff02
-
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace ConnyConsole.Infrastructure;
 
-public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> logger) : IDisposable
+/// <inheritdoc/>
+public sealed class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSource> logger)
+    : CancellationTokenSource
 {
-    private bool _gracefulCancel = true;
-    private readonly CancellationTokenSource _cancellationTokenSource = new();
-
-    public CancellationToken CancellationToken => _cancellationTokenSource.Token;
-
-    /// <summary>
-    /// Releases the resources used by this <see cref="CancellationTokenSource"/>
-    /// </summary>
-    /// <remarks>
-    /// This method is not thread-safe for any other concurrent calls.
-    /// </remarks>
-    public void Dispose() => _cancellationTokenSource.Dispose();
+    private bool _isGracefulCancelled = true;
 
     /// <summary>
     /// Creates a <see cref="ConsoleCancelEventHandler"/> for a gracefully (first Ctrl+C) or forced (second Ctrl+C) application exit.
@@ -25,18 +14,20 @@ public sealed class CancellationTokenFactory(ILogger<CancellationTokenFactory> l
     /// </summary>
     /// <param name="timeout">The timeout after which the app is forcibly terminated.</param>
     /// <returns>The configured <see cref="ConsoleCancelEventHandler"/> event.</returns>
-    public ConsoleCancelEventHandler CreateHandler(TimeSpan timeout)
+    /// <remarks>This method is based on https://medium.com/@sawyer.watts/a-beginners-guide-to-net-s-hostbuilder-part-2-cancellation-857ae3e6ff02</remarks>
+    public ConsoleCancelEventHandler CreateCancellationHandler(TimeSpan timeout)
     {
         return (_, cancelEvent) =>
         {
-            if (_gracefulCancel)
+            if (_isGracefulCancelled)
             {
                 logger.LogInformation(
-                    "Received interrupt signal, attempting to shut down gracefully but will force-close in {Seconds} seconds. Send again to immediately force-close.",timeout.TotalSeconds);
+                    "Received interrupt signal, attempting to shut down gracefully but will force-close in {Seconds} seconds. Send again to immediately force-close.",
+                    timeout.TotalSeconds);
 
-                _cancellationTokenSource.Cancel();
+                Cancel();
                 cancelEvent.Cancel = true;
-                _gracefulCancel = false;
+                _isGracefulCancelled = false;
 
                 ForceExitAfterTimeout((int)timeout.TotalMilliseconds);
             }


### PR DESCRIPTION
Since a CancellationTokenSource was needed that provides a possibility
to create an event handler to register at the Console.CancelKeyPress
event, the not really factory like CancellationTokenFactory class was
renamed into ConsoleCancellationTokenSource and inherited instead from
CancellationTokenSource. By then duplicated and obsolete code was
removed and the already existing event handler creation method was
renamed.
So, now this class purpose and behavior should be more clear.

Extended the team-shared dictionary by 'hostbuilder' entry.