### PR TITLE
Add GitVersion to build w/ GitFlow configuration

### DIFF
--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -13,6 +13,7 @@ permissions:
   pull-requests: write
 
 env:
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   solutionPath: './src/ConnyConsole.sln'
 
 jobs:
@@ -28,7 +29,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '6.x.x'
+        versionSpec: '6.0.x'
     - name: Determine Version
       id: version_step # step id used as reference for output values
       uses: gittools/actions/gitversion/execute@v3.1.11
@@ -70,8 +71,6 @@ jobs:
       run: dotnet restore ${{ env.solutionPath }}
 
     - name: Prepare SonarQube analyze
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: powershell
       run: |
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.fullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
@@ -80,8 +79,6 @@ jobs:
       run: dotnet build --no-restore ${{ env.solutionPath }}
 
     - name: Run SonarQube analyze
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: powershell
       run: |
         .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -32,11 +32,11 @@ jobs:
         versionSpec: '6.0.x'
     - name: Determine Version
       id: version_step # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v3.1.11
+      uses: gittools/actions/gitversion/command@v3.1.11
       with:
         useConfigFile: true
         configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
-        updateProjectFiles: true
+        arguments: '/updateprojectfiles'
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -71,9 +71,9 @@ jobs:
     - name: Prepare SonarQube analyze
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.fullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"$GitVersion_FullSemVer" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
 
-    - name: Build ${{ env.solutionPath }} ${{ env.fullSemVer }}
+    - name: Build ${{ env.solutionPath }} $GitVersion_FullSemVer
       run: dotnet build --no-restore ${{ env.solutionPath }}
 
     - name: Run SonarQube analyze

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -37,6 +37,9 @@ jobs:
         configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
         updateProjectFiles: true
 
+    - run:
+      name: "${{ github.workflow }} ${{ env.fullSemVer }}"
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -74,7 +77,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.fullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
 
     - name: Build ${{ env.solutionPath }}
       run: dotnet build --no-restore ${{ env.solutionPath }}

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -1,5 +1,4 @@
 name: Build and analyze
-run-name: "${{ github.workflow }} ${{ env.fullSemVer }}"
 
 on:
   push:
@@ -77,7 +76,7 @@ jobs:
       run: |
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.fullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
 
-    - name: Build ${{ env.solutionPath }}
+    - name: Build ${{ env.solutionPath }} ${{ env.fullSemVer }}
       run: dotnet build --no-restore ${{ env.solutionPath }}
 
     - name: Run SonarQube analyze

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -1,4 +1,5 @@
 name: Build and analyze
+run-name: "${{ github.workflow }} ${{ env.fullSemVer }}"
 
 on:
   push:
@@ -36,9 +37,6 @@ jobs:
         useConfigFile: true
         configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
         updateProjectFiles: true
-
-    - run:
-      name: "${{ github.workflow }} ${{ env.fullSemVer }}"
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -74,7 +74,7 @@ jobs:
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet build --no-restore ${{ env.solutionPath }} -v d
+      run: dotnet build --no-restore ${{ env.solutionPath }}
 
     - name: Run SonarQube analyze
       shell: powershell

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -34,8 +34,6 @@ jobs:
       id: version_step # step id used as reference for output values
       uses: gittools/actions/gitversion/command@v3.1.11
       with:
-        useConfigFile: true
-        configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
         arguments: '/output json /l console /config GitVersion.yaml /updateprojectfiles' # have to self-define all arguments; /updateprojectfiles not impl. in execute task
 
     - name: Setup .NET

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -71,10 +71,10 @@ jobs:
     - name: Prepare SonarQube analyze
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"$GitVersion_FullSemVer" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
 
-    - name: Build ${{ env.solutionPath }} $GitVersion_FullSemVer
-      run: dotnet build --no-restore ${{ env.solutionPath }}
+    - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
+      run: dotnet build --no-restore ${{ env.solutionPath }} -v d
 
     - name: Run SonarQube analyze
       shell: powershell

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -3,7 +3,7 @@ name: Build and analyze
 on:
   push:
     branches: [develop, master]
-  pull_request:    
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [develop, master]
   workflow_dispatch:
@@ -20,14 +20,27 @@ jobs:
     name: Build and analyze
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Code checkout
+      uses: actions/checkout@v4
       with:
-        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis and for GitVersion based versioning
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v3.1.11
+      with:
+        versionSpec: '6.0.x'
+    - name: Determine Version
+      id: version_step # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v3.1.11
+      with:
+        useConfigFile: true
+        updateProjectFiles: true
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
-    - name: Set up JDK 17
+    - name: Setup JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: 17
@@ -51,16 +64,20 @@ jobs:
       run: |
         New-Item -Path .\.sonar\scanner -ItemType Directory
         dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+
     - name: Restore ${{ env.solutionPath }} dependencies
       run: dotnet restore ${{ env.solutionPath }}
+
     - name: Prepare SonarQube analyze
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: powershell
       run: |
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+
     - name: Build ${{ env.solutionPath }}
       run: dotnet build --no-restore ${{ env.solutionPath }}
+
     - name: Run SonarQube analyze
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -34,6 +34,7 @@ jobs:
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
+        configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
         updateProjectFiles: true
 
     - name: Setup .NET

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '6.0.x'
+        versionSpec: '6.x.x'
     - name: Determine Version
       id: version_step # step id used as reference for output values
       uses: gittools/actions/gitversion/execute@v3.1.11

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -34,7 +34,7 @@ jobs:
       id: version_step # step id used as reference for output values
       uses: gittools/actions/gitversion/command@v3.1.11
       with:
-        arguments: '/output json /l console /config GitVersion.yaml /updateprojectfiles' # have to self-define all arguments; /updateprojectfiles not impl. in execute task
+        arguments: '/output buildserver /l console /config GitVersion.yaml /updateprojectfiles' # have to self-define all arguments; /updateprojectfiles not impl. in execute task
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -36,7 +36,7 @@ jobs:
       with:
         useConfigFile: true
         configFilePath: GitVersion.yaml # define it specifically, because extension searches for *.yml, not *.yaml
-        arguments: '/updateprojectfiles'
+        arguments: '/output json /l console /config GitVersion.yaml /updateprojectfiles' # have to self-define all arguments; /updateprojectfiles not impl. in execute task
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/GitVersion.yaml
+++ b/GitVersion.yaml
@@ -1,0 +1,1 @@
+workflow: GitFlow/v1


### PR DESCRIPTION
Integrated GitVersion GitHub actions for automated artifact versioning
based on _SemVer2_.
To do so, it was necessary to use the GitVersion `command` step instead
of the `execution` step, because not all needed functionality was
available.
Because the GitVersion action searches for `*.yml` files only, but we
use `*.yaml`, it was necessary to define specifically GitVersion.yaml as
config file.
Further, it does not update any projects' version, so parameter
`/updateprojectfiles` must be defined.
Finally, to ensure that all by GitVersion generated variables and values
are available, even when we use the `command` step, the output type
`buildserver` is used to get those written into `$GITHUB_ENV`. So all
variables can be used later on as generally available environment
variables.