### PR TITLE
Add tests + code coverage w/ build integration

### DIFF
--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -15,6 +15,7 @@ permissions:
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   solutionPath: './src/ConnyConsole.sln'
+  builConfiguration: 'Release'
 
 jobs:
   build:
@@ -74,10 +75,10 @@ jobs:
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet build ${{ env.solutionPath }} --no-restore --configuration Release
+      run: dotnet build ${{ env.solutionPath }} --no-restore -c ${{ env.buildConfiguration }}
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet test ${{ env.solutionPath }} --no-build --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
+      run: dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -15,7 +15,7 @@ permissions:
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   solutionPath: './src/ConnyConsole.sln'
-  builConfiguration: 'Release'
+  buildConfiguration: 'Release'
 
 jobs:
   build:
@@ -77,7 +77,7 @@ jobs:
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
       run: dotnet build ${{ env.solutionPath }} --no-restore -c ${{ env.buildConfiguration }}
 
-    - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
+    - name: Test ${{ env.solutionPath }}
       run: dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -78,7 +78,7 @@ jobs:
       run: dotnet build ${{ env.solutionPath }} --no-restore -c ${{ env.buildConfiguration }}
 
     - name: Test ${{ env.solutionPath }}
-      run: dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
+      run: dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger "GitHubActions" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -72,10 +72,10 @@ jobs:
       shell: powershell
       run: >
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /o:"haggi13"
-          /d:sonar.host.url="https://sonarcloud.io"
-          /v:"${{ env.GitVersion_FullSemVer }}"
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
-          /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
+        /d:sonar.host.url="https://sonarcloud.io"
+        /v:"${{ env.GitVersion_FullSemVer }}"
+        /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
       run: dotnet build ${{ env.solutionPath }} --no-restore -c ${{ env.buildConfiguration }}
@@ -83,9 +83,9 @@ jobs:
     - name: Test ${{ env.solutionPath }}
       run: >
         dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger "GitHubActions"
-          /p:CollectCoverage=true
-          /p:CoverletOutputFormat=opencover
-          /p:CoverletOutput="./../../TestResults/"
+        /p:CollectCoverage=true
+        /p:CoverletOutputFormat=opencover
+        /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  solutionPath: './src/ConnyConsole.sln'
+  solutionPath: 'ConnyConsole.sln'
 
 jobs:
   build:
@@ -71,10 +71,20 @@ jobs:
     - name: Prepare SonarQube analyze
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet build --no-restore ${{ env.solutionPath }}
+      run: dotnet build --no-restore --configuration Release ${{ env.solutionPath }}
+
+    - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
+      run: dotnet test --no-build --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
+
+    - name: Upload dotnet test results
+      uses: actions/upload-artifact@v4
+      with:
+        path: ./TestResults/
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}
 
     - name: Run SonarQube analyze
       shell: powershell

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -74,10 +74,10 @@ jobs:
         .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet build --no-restore --configuration Release ${{ env.solutionPath }}
+      run: dotnet build ${{ env.solutionPath }} --no-restore --configuration Release
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
-      run: dotnet test --no-build --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
+      run: dotnet test ${{ env.solutionPath }} --no-build --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -82,7 +82,8 @@ jobs:
 
     - name: Test ${{ env.solutionPath }}
       run: >
-        dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger "GitHubActions"
+        dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }}
+        --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=opencover
         /p:CoverletOutput="./../../TestResults/"

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -83,6 +83,8 @@ jobs:
     - name: Test ${{ env.solutionPath }}
       run: >
         dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }}
+        --logger trx
+        --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=opencover
@@ -91,6 +93,7 @@ jobs:
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4
       with:
+        name: TestResults
         path: ./TestResults/
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -13,7 +13,6 @@ permissions:
   pull-requests: write
 
 env:
-  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   solutionPath: './src/ConnyConsole.sln'
   buildConfiguration: 'Release'
 
@@ -71,14 +70,22 @@ jobs:
 
     - name: Prepare SonarQube analyze
       shell: powershell
-      run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /v:"${{ env.GitVersion_FullSemVer }}" /o:"haggi13" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
+      run: >
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"HaGGi13_ConnyConsole" /o:"haggi13"
+          /d:sonar.host.url="https://sonarcloud.io"
+          /v:"${{ env.GitVersion_FullSemVer }}"
+          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
 
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
       run: dotnet build ${{ env.solutionPath }} --no-restore -c ${{ env.buildConfiguration }}
 
     - name: Test ${{ env.solutionPath }}
-      run: dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger "GitHubActions" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./../../TestResults/"
+      run: >
+        dotnet test ${{ env.solutionPath }} --no-build -c ${{ env.buildConfiguration }} --logger "GitHubActions"
+          /p:CollectCoverage=true
+          /p:CoverletOutputFormat=opencover
+          /p:CoverletOutput="./../../TestResults/"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-connyconsole.yaml
+++ b/.github/workflows/build-connyconsole.yaml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  solutionPath: 'ConnyConsole.sln'
+  solutionPath: './src/ConnyConsole.sln'
 
 jobs:
   build:

--- a/src/ConnyConsole.Tests/AppTests.cs
+++ b/src/ConnyConsole.Tests/AppTests.cs
@@ -1,0 +1,49 @@
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using ConnyConsole.Infrastructure;
+using ConnyConsole.Settings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+
+namespace ConnyConsole.Tests;
+
+public class AppTests
+{
+    private readonly IOptions<AppSettings> _options;
+    private readonly ConsoleCancellationTokenSource _consoleCancellationTokenSource;
+
+    public AppTests()
+    {
+        var settings = new AppSettings
+        {
+            CancellationTimeout = TimeSpan.FromMilliseconds(10),
+            LoopOutputInterval = TimeSpan.FromMilliseconds(50)
+        };
+        _options = Options.Create(settings);
+
+        var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+        _consoleCancellationTokenSource = fixture.Create<ConsoleCancellationTokenSource>();
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldLogAndExit_WhenCancellationIsRequested()
+    {
+        // Arrange
+        var logger = new FakeLogger<App>();
+        var app = new App(_options, _consoleCancellationTokenSource, logger);
+
+        // Act
+        var runTask = Task.Run(async () => await app.RunAsync().ConfigureAwait(false));
+        await Task.Delay(100); // Allow some loops to execute
+        await _consoleCancellationTokenSource.CancelAsync(); // Simulate cancellation
+        var result = await runTask.ConfigureAwait(true); // Wait for completion
+
+        // Assert
+        result.Should().Be(0);
+
+        var logMessages = logger.Collector.GetSnapshot();
+        logMessages[0].Message.Should().StartWith("I'm working");
+        logMessages[^1].Message.Should().Be("Bye bye!");
+    }
+}

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
+        <PackageReference Include="AwesomeAssertions.Analyzers" Version="0.34.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ConnyConsole\ConnyConsole.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -14,7 +14,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,9 +27,17 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -34,10 +34,6 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -19,6 +19,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -15,6 +15,10 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
         <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
         <PackageReference Include="AwesomeAssertions.Analyzers" Version="0.34.2">
           <PrivateAssets>all</PrivateAssets>

--- a/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/src/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -34,6 +34,10 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
+++ b/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
@@ -1,0 +1,142 @@
+﻿using System.Reflection;
+using ConnyConsole.Infrastructure;
+using ConnyConsole.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace ConnyConsole.Tests;
+
+public class ConsoleCancellationTokenSourceTests
+{
+    private readonly FakeLogger<ConsoleCancellationTokenSource> _logger = new();
+
+    [Fact]
+    public void CreateCancellationHandler_ShouldLogsMessageAndExit_WhenOneInterruptWithTimeout()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+        var consoleCancelEventArgs = (ConsoleCancelEventArgs)CreateConsoleCancelEventArgs(ConsoleSpecialKey.ControlC);
+
+        // Act
+        // Timout set to 0 for immediate timeout simulation
+        var handler = tokenSource.CreateCancellationHandler(TimeSpan.Zero);
+        // First Ctrl + C
+        handler.Invoke(null, consoleCancelEventArgs);
+        // ugly workaround, otherwise ExitCalled is set after it's checked below
+        Thread.Sleep(5);
+
+        // Assert
+        tokenSource.IsCancellationRequested.Should().BeTrue();
+        consoleCancelEventArgs.Cancel.Should().BeTrue();
+        tokenSource.ExitCalled.Should().BeTrue();
+
+        var logMessages = _logger.Collector.GetSnapshot();
+        logMessages.Should().HaveCount(2);
+        logMessages[0].Message.Should().Contain("Received interrupt signal")
+            .And.Contain("Send again to immediately force-close.");
+        logMessages[^1].Message.Should().Be("Timeout reached, force-closing app.");
+    }
+
+    [Fact]
+    public void CreateCancellationHandler_ShouldLogsMessageAndCancel_WhenOneInterruptWithoutTimeout()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+        var consoleCancelEventArgs = (ConsoleCancelEventArgs)CreateConsoleCancelEventArgs(ConsoleSpecialKey.ControlC);
+
+        // Act
+        // Timout set to 3 to test case w/o timeout situation
+        var handler = tokenSource.CreateCancellationHandler(TimeSpan.FromSeconds(3));
+        // First Ctrl + C
+        handler.Invoke(null, consoleCancelEventArgs);
+
+        // Assert
+        tokenSource.IsCancellationRequested.Should().BeTrue();
+        consoleCancelEventArgs.Cancel.Should().BeTrue();
+        tokenSource.ExitCalled.Should().BeFalse(); // graceful exit, not called yet because of timeout duration
+
+        var logMessages = _logger.Collector.GetSnapshot();
+        logMessages.Should().ContainSingle();
+        logMessages[0].Message.Should().Contain("Received interrupt signal")
+            .And.Contain("Send again to immediately force-close.");
+    }
+
+    [Fact]
+    public void CreateCancellationHandler_ShouldLogsMessageAndExit_WhenTwoInterrupt()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+        var consoleCancelEventArgs = (ConsoleCancelEventArgs)CreateConsoleCancelEventArgs(ConsoleSpecialKey.ControlC);
+
+        // Act
+        var handler = tokenSource.CreateCancellationHandler(TimeSpan.FromSeconds(3));
+        // First Ctrl + C
+        handler.Invoke(null, consoleCancelEventArgs);
+        // Second Ctrl + C for immediate exit
+        handler.Invoke(null, consoleCancelEventArgs);
+
+        // Assert
+        tokenSource.IsCancellationRequested.Should().BeTrue();
+        consoleCancelEventArgs.Cancel.Should().BeTrue();
+        tokenSource.ExitCalled.Should().BeTrue();
+
+        var logMessages = _logger.Collector.GetSnapshot();
+        logMessages.Should().HaveCount(2);
+        logMessages[0].Message.Should().Contain("Received interrupt signal")
+            .And.Contain("Send again to immediately force-close.");
+        logMessages[^1].Message.Should().Be("Second interrupt received, force-closing the app");
+    }
+
+    #region Timeout handling
+
+    [Fact]
+    public void CreateCancellationHandler_ThrowsArgumentOutOfRangeException_WhenNegativeTimeout()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+
+        // Act
+        // ReSharper disable once AccessToDisposedClosure
+        Action handler = () => tokenSource.CreateCancellationHandler(TimeSpan.FromSeconds(-1));
+
+        // Assert
+        handler.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CreateCancellationHandler_ThrowsArgumentOutOfRangeException_WhenMinValueTimeout()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+
+        // Act
+        // ReSharper disable once AccessToDisposedClosure
+        Action handler = () => tokenSource.CreateCancellationHandler(TimeSpan.MinValue);
+
+        // Assert
+        handler.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CreateCancellationHandler_ShouldNotThrowArgumentOutOfRangeException_WhenMaxValueTimeout()
+    {
+        // Arrange
+        using var tokenSource = new TestConsoleCancellationTokenSource(_logger);
+
+        // Act
+        // ReSharper disable once AccessToDisposedClosure
+        Action handler = () => tokenSource.CreateCancellationHandler(TimeSpan.MaxValue);
+
+        // Assert
+        handler.Should().NotThrow<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+
+    private static object CreateConsoleCancelEventArgs(ConsoleSpecialKey key)
+    {
+        var type = typeof(ConsoleCancelEventArgs);
+        var constructor = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+        return constructor.Invoke([key]);
+    }
+}

--- a/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
+++ b/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
@@ -10,7 +10,7 @@ public class ConsoleCancellationTokenSourceTests
 {
     private readonly FakeLogger<ConsoleCancellationTokenSource> _logger = new();
 
-    [Fact(Skip = "Does not properly run and sometimes succeeded and fails - unclear what's the reason.")]
+    [Fact]
     public void CreateCancellationHandler_ShouldLogsMessageAndExit_WhenOneInterruptWithTimeout()
     {
         // Arrange

--- a/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
+++ b/src/ConnyConsole.Tests/ConsoleCancellationTokenSourceTests.cs
@@ -10,7 +10,7 @@ public class ConsoleCancellationTokenSourceTests
 {
     private readonly FakeLogger<ConsoleCancellationTokenSource> _logger = new();
 
-    [Fact]
+    [Fact(Skip = "Does not properly run and sometimes succeeded and fails - unclear what's the reason.")]
     public void CreateCancellationHandler_ShouldLogsMessageAndExit_WhenOneInterruptWithTimeout()
     {
         // Arrange
@@ -22,8 +22,6 @@ public class ConsoleCancellationTokenSourceTests
         var handler = tokenSource.CreateCancellationHandler(TimeSpan.Zero);
         // First Ctrl + C
         handler.Invoke(null, consoleCancelEventArgs);
-        // ugly workaround, otherwise ExitCalled is set after it's checked below
-        Thread.Sleep(5);
 
         // Assert
         tokenSource.IsCancellationRequested.Should().BeTrue();

--- a/src/ConnyConsole.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/ConnyConsole.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,87 @@
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using ConnyConsole.Extensions;
+using ConnyConsole.Infrastructure;
+using ConnyConsole.Settings;
+using ConnyConsole.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace ConnyConsole.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    private readonly IServiceCollection _services;
+    private readonly HostBuilderContext _hostBuilderContext;
+
+
+    public ServiceCollectionExtensionsTests()
+    {
+        var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+        _services = new ServiceCollection();
+        _services.AddLogging();
+
+        _hostBuilderContext = fixture.Create<HostBuilderContext>();
+        _hostBuilderContext.Configuration = TestConfiguration.GetConfiguration();
+    }
+
+    [Fact]
+    public void AddConfiguration_ShouldRegisterDependencies_Successfully()
+    {
+        // Arrange
+        _hostBuilderContext.Configuration["AppSettings:LoopOutputInterval"] = "00:00:13";
+        _hostBuilderContext.Configuration["AppSettings:CancellationTimeout"] = "00:00:05";
+
+        // Act
+        _services.AddConfiguration(_hostBuilderContext);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        var options = serviceProvider.GetService<IOptions<AppSettings>>();
+        var app = serviceProvider.GetService<App>();
+        var consoleCancellationTokenSource = serviceProvider.GetService<ConsoleCancellationTokenSource>();
+
+        // Assert
+        options.Should().NotBeNull();
+        options.Value.Should().NotBeNull();
+        options.Value.LoopOutputInterval.Should().Be(TimeSpan.FromSeconds(13));
+        options.Value.CancellationTimeout.Should().Be(TimeSpan.FromSeconds(5));
+
+        app.Should().NotBeNull();
+        consoleCancellationTokenSource.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddConfiguration_AppRegistrationLifetime_Transient()
+    {
+        // Arrange
+        // nothing to do - already happen in ctor
+
+        // Act
+        _services.AddConfiguration(_hostBuilderContext);
+
+        var appDescriptor = _services.FirstOrDefault(s => s.ServiceType == typeof(App));
+
+        // Assert
+        appDescriptor.Should().NotBeNull();
+        appDescriptor.Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+
+    [Fact]
+    public void AddConfiguration_ConsoleCancellationTokenSourceRegistrationLifetime_Transient()
+    {
+        // Arrange
+        // nothing to do - already happen in ctor
+
+        // Act
+        _services.AddConfiguration(_hostBuilderContext);
+        var consoleCancellationTokenSourceDescriptor =
+            _services.FirstOrDefault(s => s.ServiceType == typeof(ConsoleCancellationTokenSource));
+
+        // Assert
+        consoleCancellationTokenSourceDescriptor.Should().NotBeNull();
+        consoleCancellationTokenSourceDescriptor.Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+}

--- a/src/ConnyConsole.Tests/TestHelpers/TestConfiguration.cs
+++ b/src/ConnyConsole.Tests/TestHelpers/TestConfiguration.cs
@@ -1,0 +1,54 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace ConnyConsole.Tests.TestHelpers;
+
+public static class TestConfiguration
+{
+    private const string Configuration =
+        """
+        {
+          "Serilog": {
+            "MinimumLevel": {
+              "Default": "Information",
+              "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information",
+                "Microsoft.DbLoggerCategory.Database.Command": "Information"
+              }
+            },
+            "Using": [
+              "Serilog.Sinks.File",
+              "Serilog.Sinks.Console"
+            ],
+            "WriteTo": [
+              {
+                "Name": "File",
+                "Args": {
+                  "path": "Logs/On-.log",
+                  "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u4}] {SourceContext} {Message:lj}{NewLine}{Exception}",
+                  "rollingInterval": "Day"
+                }
+              },
+              {
+                "Name": "Console",
+                "Args": {
+                  "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u4}] {SourceContext} {Message:lj}{NewLine}{Exception}"
+                }
+              }
+            ],
+            "Properties": {
+              "Application": "ConnyConsole"
+            }
+          },
+          "AppSettings": {
+            "LoopOutputInterval": "00:00:02",
+            "CancellationTimeout": "00:00:03"
+          }
+        }
+        """;
+
+    public static IConfigurationRoot GetConfiguration() => new ConfigurationBuilder()
+        .AddJsonStream(new MemoryStream(Encoding.ASCII.GetBytes(Configuration)))
+        .Build();
+}

--- a/src/ConnyConsole.Tests/TestHelpers/TestConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole.Tests/TestHelpers/TestConsoleCancellationTokenSource.cs
@@ -1,0 +1,15 @@
+using ConnyConsole.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Tests.TestHelpers;
+
+public class TestConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSource> logger)
+    : ConsoleCancellationTokenSource(logger)
+{
+    public bool ExitCalled { get; private set; }
+
+    protected override void ExitApplication()
+    {
+        ExitCalled = true;
+    }
+}

--- a/src/ConnyConsole.sln
+++ b/src/ConnyConsole.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnyConsole", "ConnyConsole/ConnyConsole.csproj", "{88969CC9-34FC-4668-902F-9D5354CE92E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnyConsole.Tests", "ConnyConsole.Tests\ConnyConsole.Tests.csproj", "{2A4024A7-B57F-4412-9ABF-12294591C2F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88969CC9-34FC-4668-902F-9D5354CE92E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A4024A7-B57F-4412-9ABF-12294591C2F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A4024A7-B57F-4412-9ABF-12294591C2F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A4024A7-B57F-4412-9ABF-12294591C2F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A4024A7-B57F-4412-9ABF-12294591C2F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
@@ -3,7 +3,7 @@
 namespace ConnyConsole.Infrastructure;
 
 /// <inheritdoc/>
-public sealed class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSource> logger)
+public class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSource> logger)
     : CancellationTokenSource
 {
     private bool _isGracefulCancelled = true;
@@ -17,6 +17,11 @@ public sealed class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTo
     /// <remarks>This method is based on https://medium.com/@sawyer.watts/a-beginners-guide-to-net-s-hostbuilder-part-2-cancellation-857ae3e6ff02</remarks>
     public ConsoleCancelEventHandler CreateCancellationHandler(TimeSpan timeout)
     {
+        if (timeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be greater or equal zero");
+        }
+
         return (_, cancelEvent) =>
         {
             if (_isGracefulCancelled)
@@ -29,11 +34,12 @@ public sealed class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTo
                 cancelEvent.Cancel = true;
                 _isGracefulCancelled = false;
 
-                ForceExitAfterTimeout((int)timeout.TotalMilliseconds);
+                EnforceExitAfterTimeout((int)timeout.TotalMilliseconds);
             }
             else
             {
                 logger.LogInformation("Second interrupt received, force-closing the app");
+                ExitApplication();
             }
         };
     }
@@ -41,16 +47,21 @@ public sealed class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTo
     /// <summary>
     /// Waits a defined timeout in milliseconds, afterward enforces the application exit.
     /// </summary>
-    private void ForceExitAfterTimeout(int timeoutInMilliseconds)
+    private void EnforceExitAfterTimeout(int timeoutInMilliseconds)
     {
         _ = new Timer(
             _ =>
             {
                 logger.LogInformation("Timeout reached, force-closing app.");
-                Environment.Exit(0);
+                ExitApplication();
             },
             state: null,
             dueTime: timeoutInMilliseconds,
             period: 0);
     }
+
+    /// <summary>
+    /// Terminate current process and return exit code 0 to the operating system.
+    /// </summary>
+    protected virtual void ExitApplication() => Environment.Exit(0);
 }

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
@@ -49,6 +49,12 @@ public class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSour
     /// </summary>
     private void EnforceExitAfterTimeout(int timeoutInMilliseconds)
     {
+        void LogAndExit()
+        {
+            logger.LogInformation("Timeout reached, force-closing app.");
+            ExitApplication();
+        }
+
         if (timeoutInMilliseconds > 0)
         {
             _ = new Timer(
@@ -60,14 +66,6 @@ public class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSour
         else
         {
             LogAndExit();
-        }
-
-        return;
-
-        void LogAndExit()
-        {
-            logger.LogInformation("Timeout reached, force-closing app.");
-            ExitApplication();
         }
     }
 

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
@@ -49,15 +49,26 @@ public class ConsoleCancellationTokenSource(ILogger<ConsoleCancellationTokenSour
     /// </summary>
     private void EnforceExitAfterTimeout(int timeoutInMilliseconds)
     {
-        _ = new Timer(
-            _ =>
-            {
-                logger.LogInformation("Timeout reached, force-closing app.");
-                ExitApplication();
-            },
-            state: null,
-            dueTime: timeoutInMilliseconds,
-            period: 0);
+        if (timeoutInMilliseconds > 0)
+        {
+            _ = new Timer(
+                _ => LogAndExit(),
+                state: null,
+                dueTime: timeoutInMilliseconds,
+                period: 0);
+        }
+        else
+        {
+            LogAndExit();
+        }
+
+        return;
+
+        void LogAndExit()
+        {
+            logger.LogInformation("Timeout reached, force-closing app.");
+            ExitApplication();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Add tests + code coverage w/ build integration

In general a test project was added and tried to cover possible and
realistic scenarios. Furthermore, now during the test execution a code
coverage report is created. The coverage information was integrated with
the SonarQube analysis too.
Both reports, test and coverage, are published as build artifacts.
Furthermore, the GitHub Actions logger was added and slightly configured
to provide more test insides within the build summary.

Please note as the App class itself does not really do anything, there's
only one test that let the loop run and simulate a graceful
cancellation.

Beside of testing the dependency registration, the registered lifetime
of classes is tested too to highlight any changes on that by failing
tests.

After using package `AutoFixture.AutoNSubstitute` the build warning
NU1603 occurred, because of a reference to `NSubstitute v2.0.3` that
references `Castle.Core v4.0.0`, but on `dotnet restore` it was tried to
resolve as v4.0.1 and ended up with 4.1.0.
To get rid of that behavior, that as well slows down the whole restore
process dramatically, NSubstitute was installed as direct dependency of
the test project.