### PR TITLE
Migrate to Central Package Management (CPM)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,39 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <!-- Enable Central Package Management for all projects under this directory -->
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- src/ConnyConsole -->
+    <PackageVersion Include="EnvironmentAbstractions" Version="5.0.0" />
+    <PackageVersion Include="EnvironmentAbstractions.BannedApiAnalyzer" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.14" />
+
+    <!-- tests/ConnyConsole.Tests -->
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
+    <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
+    <PackageVersion Include="EnvironmentAbstractions.TestHelpers" Version="5.0.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.14" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ConnyConsole is a console CLI project that uses `System.CommandLine` from Micros
     - [Configuration duration parsing](#configuration-duration-parsing)
   - [Testability](#testability)
 - [Development](#development)
+  - [Central Package Management](#central-package-management)
   - [Test implementation](#test-implementation)
   - [Pipeline](#pipeline)
 - [References/documentation](#referencesdocumentation)
@@ -200,6 +201,19 @@ private static readonly Dictionary<string, object> SupportedSettingKeys = new()
 
 # Development
 
+The Development chapter provides an overview of the project’s development setup: how NuGet dependencies and shared build settings are centralized (CPM and shared MSBuild props), which libraries and patterns are used for testing, and what the CI pipeline runs to build, test, and publish results.
+
+## Central Package Management
+
+[Central Package Management (CPM)][31] is used in ConnyConsole to ensure that all NuGet package versions are defined in a single place. This prevents version drift, simplifies upgrades, and keeps the solution consistent across all projects.
+
+- `Directory.Packages.props` file located at the solution root level and contains all packages used by projects (`*.csproj`)
+- **How to add a new package** that is used within the solution/a project
+  - Package must be added in `Directory.Packages.props` w/ version
+    - `<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />`
+  - To define in which project it is used, define it w/o in project's `*.csproj`
+    - `<PackageVersion Include="Newtonsoft.Json" />`
+
 ## Test implementation
 
 As an application is only as good as it was tested, this chapter gives some insights into how the console application tests were implemented.
@@ -281,6 +295,7 @@ The following are some used articles listed.
 [28]: src/ConnyConsole/Settings/DurationTimeParser.cs "Duration parser implementation"
 [29]: https://github.com/AwesomeAssertions/AwesomeAssertions.analyzers "GitHub: AwesomeAssertions.Analyzers"
 [30]: https://github.com/nsubstitute/NSubstitute.Analyzers "GitHub: NSubstitute.Analyzers"
+[31]: https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management "MSDocs: Central Package Management - (CPM)"
 
 <!--# badge image references -->
 

--- a/src/ConnyConsole/ConnyConsole.csproj
+++ b/src/ConnyConsole/ConnyConsole.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <ApplicationIcon>..\..\assets\icons\app-icon.ico</ApplicationIcon>
   </PropertyGroup>
 
@@ -13,23 +10,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnvironmentAbstractions" Version="5.0.0" />
-    <PackageReference Include="EnvironmentAbstractions.BannedApiAnalyzer" Version="5.0.0">
+    <PackageReference Include="EnvironmentAbstractions"  />
+    <PackageReference Include="EnvironmentAbstractions.BannedApiAnalyzer" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3"/>
-    <PackageReference Include="Serilog" Version="4.2.0"/>
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0"/>
-    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0"/>
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0"/>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0">
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.14"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ConnyConsole.Tests/ConnyConsole.Tests.csproj
+++ b/tests/ConnyConsole.Tests/ConnyConsole.Tests.csproj
@@ -1,43 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-    <PackageReference Include="AwesomeAssertions" Version="8.0.2"/>
-    <PackageReference Include="AwesomeAssertions.Analyzers" Version="0.34.2">
+    <PackageReference Include="AutoFixture.AutoNSubstitute" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="AwesomeAssertions.Analyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="EnvironmentAbstractions.TestHelpers" Version="5.0.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+    <PackageReference Include="EnvironmentAbstractions.TestHelpers"  />
+    <PackageReference Include="GitHubActionsTestLogger" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-    <PackageReference Include="NSubstitute" Version="5.3.0"/>
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.14" />
-    <PackageReference Include="xunit" Version="2.9.3"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers"  />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This change reduces long-term maintenance overhead and improves consistency across the solution by centralizing key configuration. NuGet package versions are now governed from a single source to prevent version drift and make upgrades safer and more predictable. Common build properties are also defined once to avoid repetitive project configuration and to ensure all projects stay aligned as the solution evolves.

Item: #37