### PR TITLE
Optimize by fixing Fix CA1873 Roslyn suggestion

### DIFF
--- a/src/ConnyConsole/Cli/Config/SetConfigCommand.cs
+++ b/src/ConnyConsole/Cli/Config/SetConfigCommand.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ConnyConsole.Cli.Config;
 
-public sealed class SetConfigCommand : Command
+public sealed partial class SetConfigCommand : Command
 {
     private readonly IConfigurationEditor _configurationEditor;
     private readonly ILogger _logger;
@@ -64,7 +64,7 @@ public sealed class SetConfigCommand : Command
             var scope = GetConfigurationScope(parseResult);
 
             var resultMessage = _configurationEditor.SetValue(key, value, scope);
-            _logger.LogInformation("Set setting result: {Message}", resultMessage);
+            LogSetSettingResultMessage(resultMessage);
         }
         catch (Exception exception)
         {

--- a/src/ConnyConsole/Cli/Config/SetConfigCommand.logger.cs
+++ b/src/ConnyConsole/Cli/Config/SetConfigCommand.logger.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Cli.Config;
+
+public sealed partial class SetConfigCommand
+{
+    [LoggerMessage(LogLevel.Information, "Set setting result: {message}")]
+    private partial void LogSetSettingResultMessage(string message);
+}

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.cs
@@ -3,7 +3,7 @@
 namespace ConnyConsole.Infrastructure;
 
 /// <inheritdoc />
-public class ConsoleCancellationTokenSource(
+public partial class ConsoleCancellationTokenSource(
     ILogger<ConsoleCancellationTokenSource> logger,
     IEnvironmentProvider environmentProvider)
     : CancellationTokenSource
@@ -31,9 +31,7 @@ public class ConsoleCancellationTokenSource(
         {
             if (_isGracefulCancelled)
             {
-                logger.LogInformation(
-                    "Received interrupt signal, attempting to shut down gracefully but will force-close in {Seconds} seconds. Send again to immediately force-close.",
-                    timeout.TotalSeconds);
+                LogGracefulShutdownInitiated(timeout.TotalSeconds);
 
                 Cancel();
                 cancelEvent.Cancel = true;
@@ -43,7 +41,7 @@ public class ConsoleCancellationTokenSource(
             }
             else
             {
-                logger.LogInformation("Second interrupt received, force-closing the app");
+                LogForceShutdownInitiated();
                 ExitApplication();
             }
         };
@@ -54,12 +52,6 @@ public class ConsoleCancellationTokenSource(
     /// </summary>
     private void EnforceExitAfterTimeout(int timeoutInMilliseconds)
     {
-        void LogAndExit()
-        {
-            logger.LogInformation("Timeout reached, force-closing app.");
-            ExitApplication();
-        }
-
         if (timeoutInMilliseconds > 0)
         {
             _ = new Timer(_ => LogAndExit(),
@@ -70,6 +62,14 @@ public class ConsoleCancellationTokenSource(
         else
         {
             LogAndExit();
+        }
+
+        return;
+
+        void LogAndExit()
+        {
+            LogForceShutdownAfterTimeout();
+            ExitApplication();
         }
     }
 

--- a/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.logger.cs
+++ b/src/ConnyConsole/Infrastructure/ConsoleCancellationTokenSource.logger.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Infrastructure;
+
+public sealed partial class ConsoleCancellationTokenSource
+{
+    [LoggerMessage(LogLevel.Information,
+        "Received interrupt signal, attempting to shut down gracefully but will force-close in {seconds} seconds. Send again to immediately force-close.")]
+    private partial void LogGracefulShutdownInitiated(double seconds);
+
+    [LoggerMessage(LogLevel.Information, "Second interrupt received, force-closing the app")]
+    private partial void LogForceShutdownInitiated();
+
+    [LoggerMessage(LogLevel.Information, "Timeout reached, force-closing app.")]
+    private partial void LogForceShutdownAfterTimeout();
+}

--- a/src/ConnyConsole/Services/LogService.cs
+++ b/src/ConnyConsole/Services/LogService.cs
@@ -3,35 +3,18 @@
 namespace ConnyConsole.Services;
 
 /// <inheritdoc cref="ILogService" />
-public sealed class LogService(ILogger<LogService> logger) : ILogService
+public sealed partial class LogService(ILogger<LogService> logger) : ILogService
 {
-    private const string MessageTemplate = "{Message}";
+    private const string MessageTemplate = "{message}";
 
     public void Log(LogLevel level, string? message)
     {
         var logMessage = message ?? string.Empty;
 
-        // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault - is marked by SonarQube rule csharpsquid:S3458
-        switch (level)
-        {
-            case LogLevel.Critical:
-                logger.LogCritical(MessageTemplate, logMessage);
-                break;
-            case LogLevel.Error:
-                logger.LogError(MessageTemplate, logMessage);
-                break;
-            case LogLevel.Warning:
-                logger.LogWarning(MessageTemplate, logMessage);
-                break;
-            case LogLevel.Debug:
-                logger.LogDebug(MessageTemplate, logMessage);
-                break;
-            case LogLevel.Trace:
-                logger.LogTrace(MessageTemplate, logMessage);
-                break;
-            default:
-                logger.LogInformation(MessageTemplate, logMessage);
-                break;
-        }
+        var logLevel = level == LogLevel.None
+            ? LogLevel.Information
+            : level;
+
+        LogMessage(logLevel, logMessage);
     }
 }

--- a/src/ConnyConsole/Services/LogService.logger.cs
+++ b/src/ConnyConsole/Services/LogService.logger.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConnyConsole.Services;
+
+public sealed partial class LogService
+{
+    [LoggerMessage(MessageTemplate)]
+    private partial void LogMessage(LogLevel logLevel, string message);
+}

--- a/tests/ConnyConsole.Tests/Services/LogServiceTests.cs
+++ b/tests/ConnyConsole.Tests/Services/LogServiceTests.cs
@@ -226,7 +226,7 @@ public class LogServiceTests
     {
         // Arrange
         var logService = new LogService(_logger);
-        var message = $"   {TestMessage}   ";
+        const string message = $"   {TestMessage}   ";
 
         // Act
         logService.Log(LogLevel.Information, message);


### PR DESCRIPTION
Replaced inline log messages with `LoggerMessage` attribute based logging methods across classes. For readability they were extracted into separate files following the name schema `<filename>.logger.cs`. This was done to prevent a log execution validation of not execute log actions, because the log level not being met or because the logger is disabled in general. As all command paths are hot path, this was worth in regards of performance.